### PR TITLE
Adds basic zwarning flags

### DIFF
--- a/py/redrock/__init__.py
+++ b/py/redrock/__init__.py
@@ -1,9 +1,11 @@
 '''
 Redrock does stuff
 '''
+from __future__ import absolute_import, division, print_function
 
 __version__ = '0.0.0.dev'
 
 from . import rebin
 from . import zscan
 from . import pickz
+from . import zwarning

--- a/py/redrock/pickz.py
+++ b/py/redrock/pickz.py
@@ -1,25 +1,53 @@
+from __future__ import absolute_import, division, print_function
+
 import numpy as np
-import redrock.zscan
+import redrock
+from redrock.zwarning import ZWarningMask as ZW
 
 def pickz(zchi2, redshifts, spectra, template):
     '''Refines redshift measurement
     '''
+    #- Scan at a finer resolution around the initial minimum
     zmin = redshifts[np.argmin(zchi2)]
     dz = 0.001
     zz = np.linspace(zmin-dz, zmin+dz, 21)
     zzchi2 = redrock.zscan.calc_zchi2(zz, spectra, template)
     chi2min = np.min(zzchi2)
 
+    #- Fit a parabola to that finder resolution chi2 vs. z scan
     zmin = zz[np.argmin(zzchi2)]
-
     jj = (zzchi2 < np.min(zzchi2)+50)
     p = np.polyfit(zz[jj], zzchi2[jj], 2)
 
+    #- For zwarning mask bits
+    zwarn = 0
+
+    #- Get minimum and error from the parabola fit parameters
     a, b, c = p
     zbest = -b/(2*a)
     chi2min = c - b**2/(4*a)
-    zp = (-b + np.sqrt(b**2 - 4*a*(c-1-chi2min))) / (2*a)
-    zerr = zp-zbest
+    blat = b**2 - 4*a*(c-1-chi2min)
+    if blat >= 0:
+        zp = (-b + np.sqrt(blat)) / (2*a)
+        zerr = zp-zbest
+    else:
+        zerr = 1e6
+        zwarn |= ZW.BAD_MINFIT
 
-    return zbest, zerr
+    #- Initial minimum or best fit too close to edge of redshift range
+    if zbest < redshifts[1] or zbest > redshifts[-2]:
+        zwarn |= ZW.Z_FITLIMIT
+    if zmin < redshifts[1] or zmin > redshifts[-2]:
+        zwarn |= ZW.Z_FITLIMIT
+        
+    #- parabola minimum outside fit range
+    if zbest < zz[0] or zbest > zz[-1]:
+        zwarn |= ZW.BAD_MINFIT
+       
+    #- Parabola fit considerably different than minimum of scan 
+    #- (somewhat arbitrary cutoff)
+    if abs(zbest - zmin) > 0.01:
+        zwarn |= ZW.BAD_MINFIT
+        
+    return zbest, zerr, zwarn
 

--- a/py/redrock/test/test_zscan.py
+++ b/py/redrock/test/test_zscan.py
@@ -38,7 +38,7 @@ class TestZScan(unittest.TestCase):
         #- Create some noisy spectra on different wavelength grids
         spectra = list()
         sn2 = 0.0;
-        a = [100, 100]
+        a = [200, 200]
         for i in range(5):
             wave = np.arange(210+10*i, 400+10*i, 2.1)
             nwave = len(wave)
@@ -73,7 +73,16 @@ class TestZScan(unittest.TestCase):
             self.assertEqual(Tfit[i].shape, (len(spectra[i]['flux']), 2))
             
         #- Also test pickz since we are here
-        zbest, zerr = redrock.pickz.pickz(zchi2, redshifts, spectra, template)
+        zbest, zerr, zwarn = redrock.pickz.pickz(zchi2, redshifts, spectra, template)
+        self.assertAlmostEqual(zbest, z, delta=0.01)
+        self.assertLess(zerr, 0.01)
+        self.assertEqual(zwarn, 0)
+        
+        #- Test zwarning
+        zchi2[0] = 0
+        zbest, zerr, zwarn = redrock.pickz.pickz(zchi2, redshifts, spectra, template)
+        self.assertNotEqual(zwarn, 0)
+        
                 
 if __name__ == '__main__':
     unittest.main()

--- a/py/redrock/zwarning.py
+++ b/py/redrock/zwarning.py
@@ -14,12 +14,12 @@ class ZWarningMask(object):
     SKY               = 0**2  #- sky fiber
     LITTLE_COVERAGE   = 1**2  #- too little wavelength coverage
     SMALL_DELTA_CHI2  = 2**2  #- chi-squared of best fit is too close to that of second best
-    NEGATIVE_MODEL    = 3**2  #- synthetic spectrum is negative (only set for stars and QSOs)
+    NEGATIVE_MODEL    = 3**2  #- synthetic spectrum is negative
     MANY_OUTLIERS     = 4**2  #- fraction of points more than 5 sigma away from best model is too large (>0.05)
-    Z_FITLIMIT        = 5**2  #- chi-squared minimum at edge of the redshift fitting range (Z_ERR set to -1)
+    Z_FITLIMIT        = 5**2  #- chi-squared minimum at edge of the redshift fitting range
     NEGATIVE_EMISSION = 6**2  #- a QSO line exhibits negative emission, triggered only in QSO spectra, if  C_IV, C_III, Mg_II, H_beta, or H_alpha has LINEAREA + 3 * LINEAREA_ERR < 0
-    UNPLUGGED         = 7**2  #- the fiber was unplugged, so no spectrum obtained
-    BAD_TARGET        = 8**2  #- catastrophically bad targeting data (e.g. ASTROMBAD in CALIB_STATUS)
+    UNPLUGGED         = 7**2  #- the fiber was unplugged/broken, so no spectrum obtained
+    BAD_TARGET        = 8**2  #- catastrophically bad targeting data
     NODATA            = 9**2  #- No data for this fiber, e.g. because spectrograph was broken during this exposure (ivar=0 for all pixels)
     BAD_MINFIT        = 10**2 #- Bad parabola fit to the chi2 minimum
 

--- a/py/redrock/zwarning.py
+++ b/py/redrock/zwarning.py
@@ -1,0 +1,25 @@
+"""
+redrock.zwarning
+
+Mask bit definitions for zwarning
+
+WARNING on the warnings: not all of these are implemented yet.
+"""
+
+#- TODO: Consider using something like desispec.maskbits to provide a more
+#- convenient wrapper class (probably copy it here; don't make a dependency)
+#- That class as-is would bring in a yaml dependency.
+
+class ZWarningMask(object):
+    SKY               = 0**2  #- sky fiber
+    LITTLE_COVERAGE   = 1**2  #- too little wavelength coverage
+    SMALL_DELTA_CHI2  = 2**2  #- chi-squared of best fit is too close to that of second best
+    NEGATIVE_MODEL    = 3**2  #- synthetic spectrum is negative (only set for stars and QSOs)
+    MANY_OUTLIERS     = 4**2  #- fraction of points more than 5 sigma away from best model is too large (>0.05)
+    Z_FITLIMIT        = 5**2  #- chi-squared minimum at edge of the redshift fitting range (Z_ERR set to -1)
+    NEGATIVE_EMISSION = 6**2  #- a QSO line exhibits negative emission, triggered only in QSO spectra, if  C_IV, C_III, Mg_II, H_beta, or H_alpha has LINEAREA + 3 * LINEAREA_ERR < 0
+    UNPLUGGED         = 7**2  #- the fiber was unplugged, so no spectrum obtained
+    BAD_TARGET        = 8**2  #- catastrophically bad targeting data (e.g. ASTROMBAD in CALIB_STATUS)
+    NODATA            = 9**2  #- No data for this fiber, e.g. because spectrograph was broken during this exposure (ivar=0 for all pixels)
+    BAD_MINFIT        = 10**2 #- Bad parabola fit to the chi2 minimum
+


### PR DESCRIPTION
Adds basic zwarning flags, defined in redrock.zwarning.ZWarningMask to implement issue #5.  These are based upon the BOSS ZWARNING flags, with the addition of bit 10 to flag bad parabola fits to the chi2 vs. z scan.

Right now only BAD_MINFIT and Z_FITLIMIT are set.  Some (like SKY or UNPLUGGED) may never be set by redrock itself, but I wanted to keep bit alignment with BOSS ZWARNING.