### PR TITLE
enables Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,5 @@ python:
 # command to install dependencies
 install: "source etc/travis_setup.sh"
 # command to run tests
-script: nosetests
+# script: nosetests
+script: python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+python:
+  - "2.7"
+#  - "3.2"
+#  - "3.3"
+#  - "3.4"
+#  - "3.5"
+# command to install dependencies
+install: "source etc/travis_setup.sh"
+# command to run tests
+script: nosetests

--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,9 @@
 redrock
 =======
 
+.. image:: https://travis-ci.org/sbailey/redrock.svg?branch=master
+    :target: https://travis-ci.org/sbailey/redrock
+
 Redshift fitting for spectroperfectionism
 
 | Stephen Bailey & David Schlegel

--- a/etc/travis_setup.sh
+++ b/etc/travis_setup.sh
@@ -11,7 +11,7 @@ chmod +x miniconda.sh
 export PATH=/home/travis/miniconda/bin:$PATH
 conda update --yes conda
 
-conda create --yes -n test -c python=$PYTHON_VERSION pip
+conda create --yes -n test -c python=$TRAVIS_PYTHON_VERSION pip
 source activate test
 
 # CORE DEPENDENCIES

--- a/etc/travis_setup.sh
+++ b/etc/travis_setup.sh
@@ -29,7 +29,7 @@ source activate test
 conda install --yes numpy scipy astropy h5py numba
 
 echo '----------------------------------------------------------------------'
-echo $PYTHONPATH
+echo PYTHONPATH: $PYTHONPATH
 which python
 which nosetests
 echo '----------------------------------------------------------------------'
@@ -41,3 +41,5 @@ wget https://github.com/sbailey/redrock-templates/archive/${RR_TEMPLATE_VER}.tar
 tar -xzf ${RR_TEMPLATE_VER}.tar.gz
 mv redrock-templates-${RR_TEMPLATE_VER} templates
 rm ${RR_TEMPLATE_VER}.tar.gz
+cd ../../
+pwd

--- a/etc/travis_setup.sh
+++ b/etc/travis_setup.sh
@@ -4,7 +4,14 @@
 set -e
 
 # CONDA
-conda create --yes -n test -c astropy-ci-extras python=$PYTHON_VERSION pip
+# Install conda
+wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+chmod +x miniconda.sh
+./miniconda.sh -b -p $HOME/miniconda
+export PATH=/home/travis/miniconda/bin:$PATH
+conda update --yes conda
+
+conda create --yes -n test -c python=$PYTHON_VERSION pip
 source activate test
 
 # CORE DEPENDENCIES

--- a/etc/travis_setup.sh
+++ b/etc/travis_setup.sh
@@ -3,6 +3,9 @@
 #- Fail early, fail often
 set -e
 
+# For debugging
+printenv
+
 # CONDA
 # Install conda
 wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh

--- a/etc/travis_setup.sh
+++ b/etc/travis_setup.sh
@@ -20,11 +20,15 @@ source activate test
 # CORE DEPENDENCIES
 # conda install --yes pytest Cython jinja2 psutil pyyaml requests
 
-# NUMPY scipy
-conda install --yes numpy scipy astropy h5py numba
+# from the .travis.yml in https://github.com/numba
+conda install --yes -c numba llvmdev="3.7*"
+git clone git://github.com/numba/llvmlite.git -q
+cd llvmlite && python setup.py build && python setup.py install -q >/dev/null && cd ..
 
-# Get templates
+# numpy scipy etc.
+conda install --yes numpy scipy astropy h5py
 
+# Get redrock templates
 cd py/redrock
 RR_TEMPLATE_VER=0.2
 wget https://github.com/sbailey/redrock-templates/archive/${RR_TEMPLATE_VER}.tar.gz

--- a/etc/travis_setup.sh
+++ b/etc/travis_setup.sh
@@ -31,6 +31,7 @@ conda install --yes numpy scipy astropy h5py numba
 echo '----------------------------------------------------------------------'
 echo $PYTHONPATH
 which python
+which nosetests
 echo '----------------------------------------------------------------------'
 
 # Get redrock templates

--- a/etc/travis_setup.sh
+++ b/etc/travis_setup.sh
@@ -21,12 +21,17 @@ source activate test
 # conda install --yes pytest Cython jinja2 psutil pyyaml requests
 
 # from the .travis.yml in https://github.com/numba
-conda install --yes -c numba llvmdev="3.7*"
-git clone git://github.com/numba/llvmlite.git -q
-cd llvmlite && python setup.py build && python setup.py install -q >/dev/null && cd ..
+# conda install --yes -c numba llvmdev="3.7*"
+# git clone git://github.com/numba/llvmlite.git -q
+# cd llvmlite && python setup.py build && python setup.py install -q >/dev/null && cd ..
 
 # numpy scipy etc.
-conda install --yes numpy scipy astropy h5py
+conda install --yes numpy scipy astropy h5py numba
+
+echo '----------------------------------------------------------------------'
+echo $PYTHONPATH
+which python
+echo '----------------------------------------------------------------------'
 
 # Get redrock templates
 cd py/redrock

--- a/etc/travis_setup.sh
+++ b/etc/travis_setup.sh
@@ -14,7 +14,7 @@ chmod +x miniconda.sh
 export PATH=/home/travis/miniconda/bin:$PATH
 conda update --yes conda
 
-conda create --yes -n test -c python=$TRAVIS_PYTHON_VERSION pip
+conda create --yes -n test python=$TRAVIS_PYTHON_VERSION pip
 source activate test
 
 # CORE DEPENDENCIES

--- a/etc/travis_setup.sh
+++ b/etc/travis_setup.sh
@@ -17,22 +17,8 @@ conda update --yes conda
 conda create --yes -n test python=$TRAVIS_PYTHON_VERSION pip
 source activate test
 
-# CORE DEPENDENCIES
-# conda install --yes pytest Cython jinja2 psutil pyyaml requests
-
-# from the .travis.yml in https://github.com/numba
-# conda install --yes -c numba llvmdev="3.7*"
-# git clone git://github.com/numba/llvmlite.git -q
-# cd llvmlite && python setup.py build && python setup.py install -q >/dev/null && cd ..
-
 # numpy scipy etc.
 conda install --yes numpy scipy astropy h5py numba
-
-echo '----------------------------------------------------------------------'
-echo PYTHONPATH: $PYTHONPATH
-which python
-which nosetests
-echo '----------------------------------------------------------------------'
 
 # Get redrock templates
 cd py/redrock
@@ -42,4 +28,3 @@ tar -xzf ${RR_TEMPLATE_VER}.tar.gz
 mv redrock-templates-${RR_TEMPLATE_VER} templates
 rm ${RR_TEMPLATE_VER}.tar.gz
 cd ../../
-pwd

--- a/etc/travis_setup.sh
+++ b/etc/travis_setup.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -x
+
+#- Fail early, fail often
+set -e
+
+# CONDA
+conda create --yes -n test -c astropy-ci-extras python=$PYTHON_VERSION pip
+source activate test
+
+# CORE DEPENDENCIES
+# conda install --yes pytest Cython jinja2 psutil pyyaml requests
+
+# NUMPY scipy
+conda install --yes numpy scipy astropy h5py numba
+
+# Get templates
+
+cd py/redrock
+RR_TEMPLATE_VER=0.2
+wget https://github.com/sbailey/redrock-templates/archive/${RR_TEMPLATE_VER}.tar.gz
+tar -xzf ${RR_TEMPLATE_VER}.tar.gz
+mv redrock-templates-${RR_TEMPLATE_VER} templates
+rm ${RR_TEMPLATE_VER}.tar.gz

--- a/py/redrock/io.py
+++ b/py/redrock/io.py
@@ -63,16 +63,26 @@ def read_template(filename):
 
 def find_templates(template_dir=None):
     '''
-    Return list of redrock-*.fits template files found in either
-    template_dir or $RR_TEMPLATE_DIR
+    Return list of redrock-*.fits template files
+    
+    Search directories in this order, returning results from first one found:
+        * template_dir
+        * $RR_TEMPLATE_DIR
+        * {redrock_code}/templates/
     '''
     if template_dir is None:
-        template_dir = os.getenv('RR_TEMPLATE_DIR')
+        if 'RR_TEMPLATE_DIR' in os.environ:
+            template_dir = os.environ['RR_TEMPLATE_DIR']
+        else:
+            thisdir = os.path.dirname(os.__file__)
+            tempdir = os.path.join(os.path.abspath(thisdir), 'templates')
+            if os.path.exists(tempdir):
+                template_dir = tempdir
         
     if template_dir is None:
-        raise IOError('ERROR: must provide template_dir or $RR_TEMPLATE_DIR')
+        raise IOError("ERROR: can't find template_dir, $RR_TEMPLATE_DIR, or {rrcode}/templates/")
 
-    return glob(os.path.join(template_dir, 'redrock-*.fits'))
+    return glob(os.path.join(template_dir, 'rrtemplate-*.fits'))
 
 def read_templates(template_list=None, template_dir=None):
     '''

--- a/py/redrock/io.py
+++ b/py/redrock/io.py
@@ -74,7 +74,7 @@ def find_templates(template_dir=None):
         if 'RR_TEMPLATE_DIR' in os.environ:
             template_dir = os.environ['RR_TEMPLATE_DIR']
         else:
-            thisdir = os.path.dirname(os.__file__)
+            thisdir = os.path.dirname(__file__)
             tempdir = os.path.join(os.path.abspath(thisdir), 'templates')
             if os.path.exists(tempdir):
                 template_dir = tempdir

--- a/py/redrock/test/test_io.py
+++ b/py/redrock/test/test_io.py
@@ -30,7 +30,7 @@ class TestIO(unittest.TestCase):
         else:
             self.assertTrue(x2 is io.native_endian(x2))
                 
-    @unittest.skipIf('RR_TEMPLATE_DIR' not in os.environ, '$RR_TEMPLATE_DIR not set')
+    ### @unittest.skipIf('RR_TEMPLATE_DIR' not in os.environ, '$RR_TEMPLATE_DIR not set')
     def test_find_templates(self):
         templates = io.find_templates()
         self.assertTrue(len(templates) > 0)
@@ -38,7 +38,7 @@ class TestIO(unittest.TestCase):
         templates = io.find_templates(template_dir = template_dir)
         self.assertTrue(len(templates) > 0)
         
-    @unittest.skipIf('RR_TEMPLATE_DIR' not in os.environ, '$RR_TEMPLATE_DIR not set')
+    ### @unittest.skipIf('RR_TEMPLATE_DIR' not in os.environ, '$RR_TEMPLATE_DIR not set')
     def test_read_templates(self):
         for template in io.read_templates():
             self.assertIn('wave', template)

--- a/setup.py
+++ b/setup.py
@@ -13,10 +13,10 @@ setup_keywords = dict()
 #
 setup_keywords['name'] = 'redrock'
 setup_keywords['description'] = 'Redrock redshift fitter'
-setup_keywords['author'] = 'DESI Collaboration'
-setup_keywords['author_email'] = 'desi-data@desi.lbl.gov'
+setup_keywords['author'] = 'Stephen Bailey'
+setup_keywords['author_email'] = 'StephenBailey@lbl.gov'
 setup_keywords['license'] = 'BSD'
-setup_keywords['url'] = 'https://github.com/desihub/redrock'
+setup_keywords['url'] = 'https://github.com/sbailey/redrock'
 #
 # END OF SETTINGS THAT NEED TO BE CHANGED.
 #
@@ -63,12 +63,25 @@ if os.path.isdir('bin'):
         if not os.path.basename(fname).endswith('.rst')]
 setup_keywords['provides'] = [setup_keywords['name']]
 setup_keywords['requires'] = ['Python (>2.7.0)']
-#setup_keywords['install_requires'] = ['Python (>2.6.0)']
 setup_keywords['zip_safe'] = False
 setup_keywords['use_2to3'] = True
 setup_keywords['packages'] = find_packages('py')
 setup_keywords['package_dir'] = {'':'py'}
 setup_keywords['test_suite'] = 'redrock.test.test_suite'
+
+#- Load requirements.txt
+# with open('requirements.txt') as fx:
+#     required = list()
+#     for line in fx:
+#         line = line.strip()
+#         if not line.startswith('#') and len(line) > 1:
+#             required.append(line)
+#             
+# setup_keywords['install_requires'] = required
+
+if not 'RR_TEMPLATE_DIR' in os.environ:
+    setup_keywords['package_data'] = {'redrock': ['templates/*.fits']}
+
 #
 # Run setup command.
 #


### PR DESCRIPTION
This branch was originally about cleaning up the install procedure.  In the end it has become about enabling travis tests and setting the framework for a cleaner install (in particular, looking for templates in redrock/templates/ if $RR_TEMPLATE_DIR isn't set.  The actual "python setup.py install" itself isn't cleaned up yet, but merging now to get the above items into master before continuing.