### PR TITLE
Parallelize zscan

### DIFF
--- a/bin/rrdesi
+++ b/bin/rrdesi
@@ -16,7 +16,6 @@ parser = optparse.OptionParser(usage = "%prog [options] brickfile1 brickfile2...
 parser.add_option("-t", "--templates", type="string",  help="template file or directory")
 parser.add_option("-o", "--output", type="string",  help="output file")
 parser.add_option("-n", "--ntargets", type=int,  help="number of targets to process")
-parser.add_option(      "--npoly", type=int,  help="number of background polynomial terms [%default]", default=0)
 parser.add_option("--debug", help="debug with ipython", action="store_true")
 
 opts, brickfiles = parser.parse_args()
@@ -34,7 +33,7 @@ if opts.ntargets is not None:
     targets = targets[0:opts.ntargets]
 
 templates = redrock.io.read_templates(opts.templates)
-results = redrock.zfind(targets, templates[0:2], npoly=opts.npoly)
+results = redrock.zfind(targets, templates)
 redrock.io.write_zscan(opts.output, results, clobber=True)
 
 if opts.debug:

--- a/py/redrock/pickz.py
+++ b/py/redrock/pickz.py
@@ -40,7 +40,7 @@ def minfit(x, y):
 
     return c, xmin, ymin, sigma
 
-def pickz(zchi2, redshifts, spectra, template, npoly=0):
+def pickz(zchi2, redshifts, spectra, template):
     '''Refines redshift measurement
     '''
     assert len(zchi2) == len(redshifts)
@@ -53,12 +53,12 @@ def pickz(zchi2, redshifts, spectra, template, npoly=0):
 
     #- refit at higher sampling around +-5 sigma
     zz = np.linspace(zmin-5*sigma, zmin+5*sigma, 11)
-    zzchi2 = redrock.zscan.calc_zchi2(zz, spectra, template, npoly=npoly)
+    zzchi2 = redrock.zscan.calc_zchi2(zz, spectra, template)
     c, zmin, chi2min, sigma = minfit(zz, zzchi2)
 
     #- update fit around +-5 sigma
     zz = np.linspace(zmin-5*sigma, zmin+5*sigma, 11)
-    zzchi2 = redrock.zscan.calc_zchi2(zz, spectra, template, npoly=npoly)
+    zzchi2 = redrock.zscan.calc_zchi2(zz, spectra, template)
     c, zmin, chi2min, sigma = minfit(zz, zzchi2)
     
     zbest = zmin

--- a/py/redrock/test/test_zscan.py
+++ b/py/redrock/test/test_zscan.py
@@ -56,13 +56,10 @@ class TestZScan(unittest.TestCase):
             spectra.append( dict(wave=wave, flux=flux, ivar=ivar, R=R) )
 
         redshifts = np.linspace(0.3, 0.7, 200)
-        zchi2 = redrock.zscan.calc_zchi2(redshifts, spectra, template, npoly=2)
+        zchi2 = redrock.zscan.calc_zchi2(redshifts, spectra, template)
 
         zmin = redshifts[np.argmin(zchi2)]
-
-        #- Test rchi2
         self.assertAlmostEqual(zmin, z, delta=0.005)
-        zrchi2 = redrock.zscan.calc_zchi2(redshifts[::5], spectra, template, rchi2=True)
         
         #- Test dimensions of template_fit return
         #- Too low S/N to reproducibly check afit values

--- a/py/redrock/test/test_zscan.py
+++ b/py/redrock/test/test_zscan.py
@@ -63,11 +63,11 @@ class TestZScan(unittest.TestCase):
         
         #- Test dimensions of template_fit return
         #- Too low S/N to reproducibly check afit values
-        afit, Tfit = redrock.zscan.template_fit(zmin, spectra, template)
-        self.assertEqual(len(afit), 2)
-        self.assertEqual(len(Tfit), 5)
-        for i in range(5):
-            self.assertEqual(Tfit[i].shape, (len(spectra[i]['flux']), 2))
+        # afit, Tfit = redrock.zscan.template_fit(zmin, spectra, template)
+        # self.assertEqual(len(afit), 2)
+        # self.assertEqual(len(Tfit), 5)
+        # for i in range(5):
+        #     self.assertEqual(Tfit[i].shape, (len(spectra[i]['flux']), 2))
             
         #- Also test pickz since we are here
         zbest, zerr, zwarn, chi2min = redrock.pickz.pickz(zchi2, redshifts, spectra, template)

--- a/py/redrock/zfind.py
+++ b/py/redrock/zfind.py
@@ -45,9 +45,6 @@ def zfind(targets, templates):
         zz = redshifts[t['type']]
         print('zchi2 scan for '+t['type'])
         
-        ### 5:38 for 100 ELGs
-        ### zchi2 = redrock.zscan.calc_zchi2_targets(zz, targets, t)
-        
         ncpu = mp.cpu_count() // 2
         ntargets = len(targets)
         chunksize = max(1, ntargets // ncpu)
@@ -67,25 +64,6 @@ def zfind(targets, templates):
             results[targetid][t['type']] = dict(
                 z=zz, zchi2=zchi2[i], zbest=zbest, zerr=zerr, zwarn=zwarn, minchi2=minchi2
             )
-
-    #-------------------------------------------------------------------------
-    #- Try each template on the spectra for each target
-    # results = dict()
-    # for i, (targetid, spectra) in enumerate(targets):
-    #     results[targetid] = dict()
-    #     for t in templates:
-    #         zz = redshifts[t['type']]
-    #         zchi2 = redrock.zscan.calc_zchi2(zz, spectra, t, npoly=npoly)
-    #     
-    #         zbest, zerr, zwarn, minchi2 = redrock.pickz.pickz(zchi2, zz, spectra, t, npoly=npoly)
-    #     
-    #         results[targetid][t['type']] = dict(
-    #             z=zz, zchi2=zchi2, zbest=zbest, zerr=zerr, zwarn=zwarn, minchi2=minchi2
-    #         )
-    #     
-    #         print('{}/{} {:20} {:6s} {:4s} {:.6f} {:.6f} {:6d} {:.2f}'.format(
-    #             i, len(targets), targetid,
-    #             t['type'], t['subtype'], zbest, zerr, zwarn, minchi2))
                 
     return results
     

--- a/py/redrock/zfind.py
+++ b/py/redrock/zfind.py
@@ -3,7 +3,7 @@ import numpy as np
 import redrock.zscan
 import redrock.pickz
 
-def zfind(targets, templates, npoly=0):
+def zfind(targets, templates):
     '''
     Given a list of targets and a list of templates, find redshifts
     
@@ -17,9 +17,6 @@ def zfind(targets, templates, npoly=0):
         templates: list of dictionaries, each of which has keys
             - wave : array of wavelengths [Angstroms]
             - flux[i,wave] : template basis vectors of flux densities
-        
-    Optional:
-        npoly: number of background polynomial terms to include
 
     Returns nested dictionary results[targetid][templatetype] with keys
         - z: array of redshifts scanned
@@ -35,23 +32,41 @@ def zfind(targets, templates, npoly=0):
         QSO  = 10**np.arange(np.log10(0.5), np.log10(4.0), 1e-3),
     )
 
-    #- Try each template on the spectra for each target
-    results = dict()    
-    for i, (targetid, spectra) in enumerate(targets):
+    results = dict()
+    for targetid, spectra in targets:
         results[targetid] = dict()
-        for t in templates:
-            zz = redshifts[t['type']]
-            zchi2 = redrock.zscan.calc_zchi2(zz, spectra, t, npoly=npoly)
-        
-            zbest, zerr, zwarn, minchi2 = redrock.pickz.pickz(zchi2, zz, spectra, t, npoly=npoly)
-        
+    
+    for t in templates:
+        zz = redshifts[t['type']]
+        print('zchi2 scan for '+t['type'])
+        zchi2 = redrock.zscan.calc_zchi2_targets(zz, targets, t)
+        print('pickz')
+        for i in range(len(targets)):
+            targetid, spectra = targets[i]
+            zbest, zerr, zwarn, minchi2 = redrock.pickz.pickz(
+                zchi2[i], zz, spectra, t)
             results[targetid][t['type']] = dict(
-                z=zz, zchi2=zchi2, zbest=zbest, zerr=zerr, zwarn=zwarn, minchi2=minchi2
+                z=zz, zchi2=zchi2[i], zbest=zbest, zerr=zerr, zwarn=zwarn, minchi2=minchi2
             )
-        
-            print('{}/{} {:20} {:6s} {:4s} {:.6f} {:.6f} {:6d} {:.2f}'.format(
-                i, len(targets), targetid,
-                t['type'], t['subtype'], zbest, zerr, zwarn, minchi2))
+
+    #-------------------------------------------------------------------------
+    #- Try each template on the spectra for each target
+    # results = dict()
+    # for i, (targetid, spectra) in enumerate(targets):
+    #     results[targetid] = dict()
+    #     for t in templates:
+    #         zz = redshifts[t['type']]
+    #         zchi2 = redrock.zscan.calc_zchi2(zz, spectra, t, npoly=npoly)
+    #     
+    #         zbest, zerr, zwarn, minchi2 = redrock.pickz.pickz(zchi2, zz, spectra, t, npoly=npoly)
+    #     
+    #         results[targetid][t['type']] = dict(
+    #             z=zz, zchi2=zchi2, zbest=zbest, zerr=zerr, zwarn=zwarn, minchi2=minchi2
+    #         )
+    #     
+    #         print('{}/{} {:20} {:6s} {:4s} {:.6f} {:.6f} {:6d} {:.2f}'.format(
+    #             i, len(targets), targetid,
+    #             t['type'], t['subtype'], zbest, zerr, zwarn, minchi2))
                 
     return results
     

--- a/py/redrock/zscan.py
+++ b/py/redrock/zscan.py
@@ -4,12 +4,17 @@ import numpy as np
 import scipy.sparse
 from redrock import rebin
 
-def calc_zchi2(redshifts, spectra, template, rchi2=False, npoly=0):
+def calc_zchi2(redshifts, spectra, template):
+    target = (0, spectra)
+    return calc_zchi2_targets(redshifts, [target,], template)[0]
+
+def calc_zchi2_targets(redshifts, targets, template):
     '''Calculates chi2 vs. redshift for a given PCA template.
 
     Args:
         redshifts: array of redshifts to evaluate
-        spectra: list of dictionaries, each of which has keys
+        targets : list of (targetid, spectra), where spectra are a list of
+            dictionaries, each of which has keys
             - wave : array of wavelengths [Angstroms]
             - flux : array of flux densities [10e-17 erg/s/cm^2/Angstrom]
             - ivar : inverse variances of flux
@@ -17,10 +22,6 @@ def calc_zchi2(redshifts, spectra, template, rchi2=False, npoly=0):
         template: dictionary with keys
             - wave : array of wavelengths [Angstroms]
             - flux[i,wave] : template basis vectors of flux densities
-
-    Optional:
-        rchi2 : if True, return reduced chi2/dof instead of chi2
-        npoly : number if Legendre poly terms to add as nuisance background
 
     Returns:
         chi2 array with one element per input redshift
@@ -31,23 +32,64 @@ def calc_zchi2(redshifts, spectra, template, rchi2=False, npoly=0):
         To use an archetype, provide a template with dimensions [1,nwave]
     '''
     nz = len(redshifts)
-    zchi2 = np.zeros(nz)
+    ntargets = len(targets)
+    zchi2 = np.zeros( (ntargets, nz) )
     
-    #- Regroup fluxes and ivars into 1D arrays
-    flux = np.concatenate( [s['flux'] for s in spectra] )
-    weights = np.concatenate( [s['ivar'] for s in spectra] )
-    nflux = len(flux)
+    #- Regroup fluxes and ivars into 1D arrays per target
+    fluxlist = list()
+    weightslist = list()
+    for targetid, spectra in targets:
+        fluxlist.append( np.concatenate( [s['flux'] for s in spectra] ) )
+        weightslist.append( np.concatenate( [s['ivar'] for s in spectra] ) )
     
+    #- NOT GENERAL AT ALL:
+    #- assume all targets have same number of spectra with same wavelengths,
+    #- so we can just use the first target spectra to get wavelength grids
+    #- for all of them
+    refspectra = targets[0][1]
+        
     #- Loop over redshifts, solving for template fit coefficients
+    nbasis = template['flux'].shape[0]
+    nflux = len(fluxlist[0])
+    Tb = np.zeros( (nflux, nbasis) )
     for i, z in enumerate(redshifts):
-        a, T = template_fit(z, spectra, template, flux=flux, weights=weights, npoly=npoly)
-        Tx = np.vstack(T)
-        zchi2[i] = np.sum( (flux - Tx.dot(a))**2 * weights )
-        if rchi2:
-            zchi2[i] /= len(flux) - 1
+        Tx = rebin_template(template, z, refspectra)
+        
+        if i%100 == 0: print('redshift', z)
+        
+        for j in range(ntargets):
+            targetid, spectra = targets[j]
+            flux = fluxlist[j]
+            weights = weightslist[j]
+            Tb = list()
+            for k, s in enumerate(spectra):
+                Tb.append(s['R'].dot(Tx[k]))
+                
+            Tb = np.vstack(Tb)
+        
+            W = scipy.sparse.dia_matrix((weights, 0), (nflux, nflux))
+            a = np.linalg.solve(Tb.T.dot(W.dot(Tb)), Tb.T.dot(W.dot(flux)))
+        
+            zchi2[j,i] = np.sum( (flux - Tb.dot(a))**2 * weights )
     
     return zchi2        
 
+def rebin_template(template, z, spectra):
+    '''rebin template to match the wavelengths of the input spectra'''
+    nbasis = template['flux'].shape[0]  #- number of template basis vectors
+    Tx = list()
+    nspec = len(spectra)
+    for i, s in enumerate(spectra):
+        Ti = np.zeros((len(s['wave']), nbasis))
+        for j in range(nbasis):
+            t = rebin.trapz_rebin((1+z)*template['wave'], template['flux'][j], s['wave'])
+            Ti[:,j] = t
+
+        Tx.append(Ti)
+    
+    return Tx
+    
+#-------------------------------------------------------------------------
 #- Cache templates rebinned onto particular wavelength grids since that is
 #- a computationally expensive operation
 _template_cache = dict()

--- a/py/redrock/zscan.py
+++ b/py/redrock/zscan.py
@@ -58,33 +58,30 @@ def calc_zchi2_targets(redshifts, targets, template):
     #- Pre-convert resolution matrices to csr for faster dot products
     for targetid, spectra in targets:
         for s in spectra:
-            s['R'] = s['R'].tocsr()
+            s['Rcsr'] = s['R'].tocsr()
     
     #- Loop over redshifts, solving for template fit coefficients
     nbasis = template['flux'].shape[0]
     nflux = len(fluxlist[0])
     Tb = np.zeros( (nflux, nbasis) )
     for i, z in enumerate(redshifts):
-        Tx = rebin_template(template, z, refspectra)
-        
-        if i%100 == 0: print('redshift', z)
-        
+        Tx = rebin_template(template, z, refspectra)        
         for j in range(ntargets):
             targetid, spectra = targets[j]
             Tb = list()
             for k, s in enumerate(spectra):
-                Tb.append(s['R'].dot(Tx[k]))
-                                
+                Tb.append(s['Rcsr'].dot(Tx[k]))
+
             Tb = np.vstack(Tb)
-        
+
             flux = fluxlist[j]
             wflux = wfluxlist[j]
             weights = weightslist[j]
             W = Wlist[j]
             a = np.linalg.solve(Tb.T.dot(W.dot(Tb)), Tb.T.dot(wflux))
-        
+
             zchi2[j,i] = np.sum( (flux - Tb.dot(a))**2 * weights )
-    
+
     return zchi2        
 
 def rebin_template(template, z, spectra):
@@ -101,84 +98,3 @@ def rebin_template(template, z, spectra):
         Tx.append(Ti)
     
     return Tx
-    
-#-------------------------------------------------------------------------
-#- Cache templates rebinned onto particular wavelength grids since that is
-#- a computationally expensive operation
-_template_cache = dict()
-
-def template_fit(z, spectra, template, flux=None, weights=None, npoly=0):
-    '''Fit a template to the data at a given redshift
-    
-    flux = sum_i a[i] template['flux'][i]
-    
-    Args:
-        z : redshift
-        spectra: list of dictionaries, each of which has keys
-            - wave : array of wavelengths [Angstroms]
-            - flux : array of flux densities [10e-17 erg/s/cm^2/Angstrom]
-            - ivar : inverse variances of flux
-            - R : spectro-perfectionism resolution matrix
-        template: dictionary with keys
-            - wave : array of wavelengths [Angstroms]
-            - flux[i,wave] : template basis vectors of flux densities
-            
-    Optional:
-        npoly: number of Legendre polynomial terms to add as nuisance background
-
-    Optional for efficiency, since they may be pre-calculated for all z:
-        flux : precalculated np.concatenate( [s['flux'] for s in spectra] )
-        weights : precalculated np.concatenate( [s['ivar'] for s in spectra] )
-        
-    Returns a, T:
-        a : coefficients that fit this template to these spectra
-        T : list of matrices which sample the template basis vectors to the
-            binning and resolution of each spectrum.
-            
-    Notes:
-        T[i].dot(a) is the model for spectra[i]['flux']
-    '''
-    
-    if flux is None:
-        flux = np.concatenate( [s['flux'] for s in spectra] )
-    if weights is None:
-        weights = np.concatenate( [s['ivar'] for s in spectra] )
-        
-    nflux = len(flux)
-
-    #- Make a list of matrices that bin the template basis for each spectrum
-    nbasis = template['flux'].shape[0]  #- number of template basis vectors
-    T = list()
-    nspec = len(spectra)
-    for i, s in enumerate(spectra):
-        Ti = np.zeros((len(s['wave']), nbasis+npoly*nspec))
-        #- Template basis
-        for j in range(nbasis):
-            key = (z, id(template), j, len(s['wave']), s['wave'][0], s['wave'][-1])
-            if key not in _template_cache:
-                t = rebin.trapz_rebin((1+z)*template['wave'], template['flux'][j], s['wave'])
-                _template_cache[key] = t
-            else:
-                t = _template_cache[key]
-                
-            Ti[:,j] = s['R'].dot(t)
-
-        #- Add legendre background terms
-        w = s['wave']
-        wx = 2 * (w-w[0]) / (w[-1] - w[0]) - 1.0  #- Map wave -> [-1,1]
-        for j in range(npoly):
-            c = np.zeros(npoly)
-            c[j] = 1.0
-            k = nbasis + i*npoly + j
-            Ti[:, k] = np.polynomial.legendre.legval(wx, c)
-        
-        T.append(Ti)
-        
-    #- Convert to a single matrix for solving `a`
-    Tx = np.vstack(T)
-    
-    #- solve s = Tx * a
-    W = scipy.sparse.dia_matrix((weights, 0), (nflux, nflux))
-    a = np.linalg.solve(Tx.T.dot(W.dot(Tx)), Tx.T.dot(W.dot(flux)))
-    return a, T
-    


### PR DESCRIPTION
This PR parallelizes the redshift scanning code using multiprocessing.

It also removes the polynomial background option — partially for simplicity while refactoring, partially because a purely additive polynomial probably isn't what we want (multiplicative would be better, or both).

This version also makes the assumption that all input targets have the same number of individual spectra and that their wavelength grids are the same.  This is sufficient for DESI tests but will need to be generalized in the future (both for DESI and for eBOSS).

The zscan matrix algebra setup is optimized to not recalculate more than it has to, but probably isn't very readable in 3 months.  That will be a future cleanup pass.